### PR TITLE
Added missing dependency on babel-preset-es2015

### DIFF
--- a/examples/basic_rendering/package.json
+++ b/examples/basic_rendering/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "babel-core": "^6.1.20",
     "babel-plugin-transform-react-jsx": "^6.1.18",
+    "babel-preset-es2015": "^6.3.13",
     "body-parser": "^1.14.1",
     "express": "^4.13.3",
     "react": "^0.14.2",


### PR DESCRIPTION
The basic example complains of a missing `es2015` folder:

```
$ python example.py 
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
127.0.0.1 - - [09/Dec/2015 20:20:04] "GET / HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/runejuhl/.local/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/runejuhl/opt/python-react/examples/basic_rendering/example.py", line 20, in index
    to_static_markup=True,
  File "/home/runejuhl/.local/lib/python2.7/site-packages/react/render.py", line 17, in render_component
    return renderer.render(path, props, to_static_markup)
  File "/home/runejuhl/.local/lib/python2.7/site-packages/react/render_server.py", line 65, in render
    'Message: {}\n\nStack trace: {}'.format(err['message'], err['stack'])
ReactRenderingError: Message: Couldn't find preset "es2015" relative to directory "/home/runejuhl/opt/python-react/examples/basic_rendering"

Stack trace: Error: Couldn't find preset "es2015" relative to directory "/home/runejuhl/opt/python-react/examples/basic_rendering"
    at OptionManager.mergePresets (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-core/lib/transformation/file/options/option-manager.js:327:17)
    at OptionManager.mergeOptions (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-core/lib/transformation/file/options/option-manager.js:287:12)
    at OptionManager.addConfig (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-core/lib/transformation/file/options/option-manager.js:221:10)
    at OptionManager.findConfigs (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-core/lib/transformation/file/options/option-manager.js:364:16)
    at OptionManager.init (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-core/lib/transformation/file/options/option-manager.js:412:12)
    at compile (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-register/lib/node.js:87:26)
    at loader (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-register/lib/node.js:130:14)
    at Object.require.extensions.(anonymous function) [as .jsx] (/home/runejuhl/opt/python-react/examples/basic_rendering/node_modules/babel-register/lib/node.js:140:7)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
```

This is due to a missing dependency on `babel-preset-es2015`.