### PR TITLE
Add option to pass a URL explicitly instead of reading from settings

### DIFF
--- a/react/render_server.py
+++ b/react/render_server.py
@@ -21,8 +21,9 @@ class RenderedComponent(object):
 
 
 class RenderServer(object):
-    def render(self, path, props=None, to_static_markup=False, request_headers=None, timeout=None):
-        url = conf.settings.RENDER_URL
+    def render(self, path, props=None, to_static_markup=False, request_headers=None, timeout=None, url=None):
+        if not url:
+            url = conf.settings.RENDER_URL
 
         if props is not None:
             serialized_props = json.dumps(props, cls=JSONEncoder)


### PR DESCRIPTION
I have a use case where I need to support both the original behavior of reading the url from settings, and the ability to pass a different url conditionally.