### PR TITLE
docs: fix simple typo, browswer -> browser

### DIFF
--- a/examples/frontend-rendering-with-webpack/README.md
+++ b/examples/frontend-rendering-with-webpack/README.md
@@ -1,7 +1,7 @@
 Running the example
 ===================
 
-As mentioned in the ***Using React on the front-end*** section, [Webpack](https://webpack.github.io/) is used to bundle the respective js files into `dist.js` and included in `index.html`. To make React attributes like `onClick` etc. work, the app has to be re-rendered (along with all the props passed down) when it loads on the browswer. React is intelligent enough to not re-paint the browser and only update the changes, thus adding all the component properties.
+As mentioned in the ***Using React on the front-end*** section, [Webpack](https://webpack.github.io/) is used to bundle the respective js files into `dist.js` and included in `index.html`. To make React attributes like `onClick` etc. work, the app has to be re-rendered (along with all the props passed down) when it loads on the browser. React is intelligent enough to not re-paint the browser and only update the changes, thus adding all the component properties.
 
 In this example, the basic_rendering example is modified to submit the Comment Form through ajax and update the Comment List by fetching the updated comments and rendering the application with new props.
 


### PR DESCRIPTION
There is a small typo in examples/frontend-rendering-with-webpack/README.md.

Should read `browser` rather than `browswer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md